### PR TITLE
Use platform-agnostic path

### DIFF
--- a/Telerik.Examples.RazorPages/Telerik.Examples.RazorPages/Pages/Index.cshtml.cs
+++ b/Telerik.Examples.RazorPages/Telerik.Examples.RazorPages/Pages/Index.cshtml.cs
@@ -24,7 +24,7 @@ namespace Telerik.Examples.RazorPages.Pages
             var foldersToExclude = new string[] { "Pages", "Shared", "EditorTemplates" };
             var fileNames = new List<string>();
             var directoryNames = new List<string>();
-            var txtPath = @".\Pages";
+            var txtPath = Path.Combine(".", "Pages");
             string[] files = Directory.GetFiles(txtPath, "*.cshtml", SearchOption.AllDirectories);
 
             foreach (var file in files)


### PR DESCRIPTION
The original usage of `.\Pages` crashes on macOS. The fix is to simply use the platform path separator instead.