### PR TITLE
example: Grid hierarchy persist expanded rows

### DIFF
--- a/Telerik.Examples.Mvc/Telerik.Examples.Mvc/Controllers/Grid/Hierarchy_Persist_Expanded_ChildrenController.cs
+++ b/Telerik.Examples.Mvc/Telerik.Examples.Mvc/Controllers/Grid/Hierarchy_Persist_Expanded_ChildrenController.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using Kendo.Mvc.UI;
+using Kendo.Mvc.Extensions;
+using Telerik.Examples.Mvc.Models;
+
+namespace Telerik.Examples.Mvc.Controllers.Grid
+{
+    public class Hierarchy_Persist_Expanded_ChildrenController : Controller
+    {
+        private static ICollection<Product> products;
+        private static ICollection<Person> people;
+        public IActionResult Hierarchy_Persist_Expanded_Children()
+        {
+            if (products == null)
+            {
+                var random = new Random();
+                products = Enumerable.Range(1, 4).Select(i => new Product
+                {
+                    Discontinued = i % 2 == 1,
+                    ProductID = i,
+                    ProductName = "Product" + i,
+                    UnitPrice = random.Next(1, 1000),
+                    UnitsInStock = random.Next(1, 1000),
+                    UnitsOnOrder = random.Next(1, 1000)
+
+                }).ToList();
+            }
+            if (people == null)
+            {
+                people = Enumerable.Range(1, 10).Select(i => new Person
+                {
+                    PersonID = i,
+                    BirthDate = DateTime.Now.AddDays(i),
+                    ProductID = i % 2 == 0 ? 1 : 2,
+                    Name = "Name" + i
+                }).ToList();
+            }
+            return View();
+        }
+        public ActionResult Read_Products([DataSourceRequest] DataSourceRequest request)
+        {
+            return Json(products.ToDataSourceResult(request));
+        }
+
+        [AcceptVerbs("Post")]
+        public ActionResult Create_Products([DataSourceRequest] DataSourceRequest request, Product product)
+        {
+            //save item to database
+            return Json(new[] { product }.ToDataSourceResult(request, ModelState));
+        }
+
+        [AcceptVerbs("Post")]
+        public ActionResult Update_Products([DataSourceRequest] DataSourceRequest request, Product product)
+        {
+            //save item to database
+            products.Add(product);
+            return Json(new[] { product }.ToDataSourceResult(request, ModelState));
+        }
+
+        public ActionResult Read_People([DataSourceRequest] DataSourceRequest request, int productID)
+        {
+            return Json(people
+                .Where(person => person.ProductID == productID)
+                .ToDataSourceResult(request));
+        }
+
+        [AcceptVerbs("Post")]
+        public ActionResult Create_People([DataSourceRequest] DataSourceRequest request, Person person)
+        {
+            //save child item to database
+            return Json(new[] { person }.ToDataSourceResult(request, ModelState));
+        }
+
+        [AcceptVerbs("Post")]
+        public ActionResult Update_People([DataSourceRequest] DataSourceRequest request, Person person)
+        {
+            //save child item to database
+            people.Add(person);
+            return Json(new[] { person }.ToDataSourceResult(request, ModelState));
+        }
+    }
+}

--- a/Telerik.Examples.Mvc/Telerik.Examples.Mvc/Views/Grid/HierarchyCrud.cshtml
+++ b/Telerik.Examples.Mvc/Telerik.Examples.Mvc/Views/Grid/HierarchyCrud.cshtml
@@ -14,7 +14,7 @@
               .Destroy(destroy => destroy.Action("Destroy_Products", "HierarchyCrud"))
               .Model(m => {
                   m.Id(id => id.ProductID);
-                  m.Field(f => f.ProductID).Editable(false);
+                  m.Field(f => f.ProductID).Editable(true);
               })
            )
           .Editable(editable => editable.Mode(GridEditMode.InLine))
@@ -62,7 +62,7 @@
           {
               model.Id(o => o.PersonID);
               model.Field(o => o.ProductID).DefaultValue(0);
-              model.Field(o => o.PersonID).Editable(false);
+              model.Field(o => o.PersonID).Editable(true);
           })
           .Create(create => create.Action("Create_People","HierarchyCrud"))
           .Read(read => read.Action("Read_People", "HierarchyCrud", new { productID = "#=ProductID#" }))

--- a/Telerik.Examples.Mvc/Telerik.Examples.Mvc/Views/Grid/Hierarchy_Persist_Expanded_Children.cshtml
+++ b/Telerik.Examples.Mvc/Telerik.Examples.Mvc/Views/Grid/Hierarchy_Persist_Expanded_Children.cshtml
@@ -1,0 +1,111 @@
+﻿@{
+    ViewData["Title"] = "Hierarchy Persist Expanded Children";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<p>Expand the Detail Template of the Grid and click <b>Add new record</b></p>
+
+@(Html.Kendo().Grid<Product>()
+          .Name("grid")
+          .DataSource(dataSource => dataSource
+              .Ajax()
+              .Read(read => read.Action("Read_Products", "Hierarchy_Persist_Expanded_Children"))
+              .Update(update => update.Action("Update_Products", "Hierarchy_Persist_Expanded_Children"))
+              .Create(create => create.Action("Create_Products", "Hierarchy_Persist_Expanded_Children"))
+              .Model(m => {
+                  m.Id(id => id.ProductID);
+                  m.Field(f => f.ProductID).Editable(true);
+              })
+           )
+          .Editable(editable => editable.Mode(GridEditMode.InLine))
+          .ToolBar(t => t.Create())
+          .Columns(columns =>
+          {
+              columns.Bound(product => product.ProductID);
+              columns.Bound(product => product.ProductName);
+              columns.Bound(product => product.UnitsInStock);
+              columns.Bound(product => product.Discontinued);
+              columns.Bound(product => product.UnitPrice);
+              columns.Bound(product => product.UnitsOnOrder);
+              columns.Command(command => {
+                  command.Edit();
+                  command.Destroy();
+              });
+          })
+          .Pageable()
+          .Sortable()
+          .Filterable()
+          .Groupable()
+          .ClientDetailTemplateId("OrdersTemplate")
+          .Events(e => e.Edit("onEdit").DetailExpand("onDetailExpand").DetailCollapse("onDetailCollapse").DataBound("onDataBound"))
+)
+
+<script type="text/kendo" id="OrdersTemplate">
+  @(Html.Kendo().Grid<Person>()
+      .Name("People#=ProductID#")
+      .Columns(columns =>
+      {
+          columns.Bound(o => o.PersonID);
+          columns.Bound(o => o.Name);
+          columns.Bound(o => o.BirthDate).Format("{0:d}");
+
+          columns.Command(command =>
+          {
+              command.Edit();
+              command.Destroy();
+          });
+      })
+      .ToolBar(toolbar => toolbar.Create())
+      .Editable(editable=>editable.Mode(GridEditMode.InLine))
+      .Pageable().Sortable().Filterable()
+      .DataSource(source => source.Ajax()
+          .Model(model =>
+          {
+              model.Id(o => o.PersonID);
+              model.Field(o => o.ProductID).DefaultValue(0);
+              model.Field(o => o.PersonID).Editable(true);
+          })
+          .Create(create => create.Action("Create_People","Hierarchy_Persist_Expanded_Children"))
+          .Read(read => read.Action("Read_People", "Hierarchy_Persist_Expanded_Children", new { productID = "#=ProductID#" }))
+          .Update(update => update.Action("Update_People", "Hierarchy_Persist_Expanded_Children"))
+      )
+      .ToClientTemplate()
+   )
+</script>
+<script>
+    var expandedRows = new Set();
+    function onDetailExpand(e) {
+        console.log("detailExpand")
+        var grid = e.sender;
+        var dataItem = grid.dataItem(e.masterRow);
+        expandedRows.add(dataItem);
+    }
+    function onDetailCollapse(e) {
+        var grid = e.sender;
+        var dataItem = grid.dataItem(e.masterRow);
+        var idToRemove;
+        expandedRows.forEach((item, idx) => {
+            var modelId = item.idField;
+            console.log(modelId);
+            console.log(item[modelId], dataItem[modelId])
+            if (item[modelId] == dataItem[modelId]) {
+                expandedRows.delete(item)
+            }
+        })
+    }
+    function onEdit(e) {
+        var grid = e.sender;
+        expandedRows.forEach(item => {
+            var row = $(`tr[data-uid=${item.uid}]`);
+            grid.expandRow(row);
+        })
+    }
+    function onDataBound(e) {
+        var grid = $("#grid").data("kendoGrid");
+        expandedRows.forEach(item => {
+            var row = $(`tr[data-uid=${item.uid}]`);
+            grid.expandRow(row);
+        })
+    }
+</script>


### PR DESCRIPTION
This example showcases how to utilize the Grid's Event handlers to persist expanded Detail Template rows when CRUD operations are performed on the parent.